### PR TITLE
feat: add sonarjs plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-sonarjs": "^0.19.0",
         "eslint-plugin-testing-library": "^5.10.0",
         "eslint-plugin-unused-imports": "^2.0.0",
         "prettier": "^2.8.3",
@@ -1867,6 +1868,17 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.19.0.tgz",
+      "integrity": "sha512-6+s5oNk5TFtVlbRxqZN7FIGmjdPCYQKaTzFPmqieCmsU1kBYDzndTeQav0xtQNwZJWu5awWfTGe8Srq9xFOGnw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/eslint-plugin-testing-library": {
@@ -6494,6 +6506,12 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "requires": {}
+    },
+    "eslint-plugin-sonarjs": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.19.0.tgz",
+      "integrity": "sha512-6+s5oNk5TFtVlbRxqZN7FIGmjdPCYQKaTzFPmqieCmsU1kBYDzndTeQav0xtQNwZJWu5awWfTGe8Srq9xFOGnw==",
       "requires": {}
     },
     "eslint-plugin-testing-library": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-sonarjs": "^0.19.0",
     "eslint-plugin-testing-library": "^5.10.0",
     "eslint-plugin-unused-imports": "^2.0.0",
     "prettier": "^2.8.3",

--- a/rules/eslint.js
+++ b/rules/eslint.js
@@ -25,7 +25,8 @@ module.exports = {
 		'prettier',
 		'unused-imports',
 		'jest-dom',
-		'testing-library'
+		'testing-library',
+		'sonarjs'
 	],
 	extends: [
 		'eslint:recommended',
@@ -35,7 +36,8 @@ module.exports = {
 		'plugin:react/recommended',
 		'plugin:react-hooks/recommended',
 		'plugin:jsx-a11y/recommended',
-		'prettier'
+		'prettier',
+		'plugin:sonarjs/recommended'
 	],
 	rules: {
 		// Vanilla rules


### PR DESCRIPTION
Add sonarjs plugin to eslint and use the recommended configuration, which is a subset of the configuration for js and ts of SonarQube (see https://rules.sonarsource.com/typescript and  https://rules.sonarsource.com/javascript).
Given that, it is suggested installing also SonalLint plugin for the IDE.

In case there are too many errors generated by this new rules in your project, override the needed rules in your eslint configuration, setting them with type 'warn', and progressively fix the warnings. When you feel comfortable, remove the override and return to have the default rules set to type 'error'.