### PR TITLE
fix: add typescript as peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "eslint-plugin-unused-imports": "^3.0.0",
         "prettier": "^3.0.1",
         "prettier-eslint": "^16.1.2",
-        "typescript": "^5.1.6"
+        "typescript": "^5.7.2"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.5.0",
@@ -36,6 +36,9 @@
         "husky": "^9.1.6",
         "is-ci": "^3.0.1",
         "semantic-release": "^24.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -9882,9 +9885,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     "eslint-plugin-unused-imports": "^3.0.0",
     "prettier": "^3.0.1",
     "prettier-eslint": "^16.1.2",
-    "typescript": "^5.1.6"
+    "typescript": "^5.7.2"
+  },
+  "peerDependencies": {
+    "typescript": "^5.4"
   }
 }


### PR DESCRIPTION
Add typescript as peer dependency. Miminum version is 5.4 which introduces the module preserve config